### PR TITLE
feat(phase8): Add observability and UI enhancements

### DIFF
--- a/infra/k8s/alertmanager-config.yaml
+++ b/infra/k8s/alertmanager-config.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+data:
+  alertmanager.yml: |
+    global:
+      resolve_timeout: 5m
+
+    route:
+      group_by: ['alertname', 'service']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 1h
+      receiver: 'webhook-sink'
+      routes:
+        - match:
+            severity: critical
+          receiver: 'webhook-sink'
+          continue: true
+
+    receivers:
+      - name: 'webhook-sink'
+        webhook_configs:
+          - url: 'http://read-model:8080/webhook/alerts'
+            send_resolved: true
+            http_config:
+              basic_auth:
+                username: 'alertmanager'
+                password: 'webhook123'
+
+    inhibit_rules:
+      - source_match:
+            severity: 'critical'
+        target_match:
+            severity: 'warning'
+        equal: ['alertname', 'service']

--- a/infra/k8s/alertmanager.yaml
+++ b/infra/k8s/alertmanager.yaml
@@ -15,8 +15,17 @@ spec:
       containers:
       - name: alertmanager
         image: prom/alertmanager:v0.25.0
+        args:
+          - "--config.file=/etc/alertmanager/alertmanager.yml"
         ports:
           - containerPort: 9093
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/alertmanager
+      volumes:
+        - name: config-volume
+          configMap:
+            name: alertmanager-config
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/prometheus-rules.yaml
+++ b/infra/k8s/prometheus-rules.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-rules
+data:
+  alert-rules.yml: |
+    groups:
+      - name: observatory-alerts
+        rules:
+          # Service Down Alert
+          - alert: ServiceDown
+            expr: up{job=~"gateway|processor"} == 0
+            for: 1m
+            labels:
+              severity: critical
+              service: "{{ $labels.job }}"
+            annotations:
+              summary: "{{ $labels.job }} service is down"
+              description: "The {{ $labels.job }} service has been unreachable for more than 1 minute."
+
+          # Job Failure Rate High (with divide-by-zero guard)
+          - alert: JobFailureRateHigh
+            expr: |
+              (
+                rate(processor_jobs_failed_total[5m]) 
+                / 
+                (rate(processor_jobs_completed_total[5m]) + rate(processor_jobs_failed_total[5m]) + 0.001)
+              ) > 0.05
+            for: 2m
+            labels:
+              severity: warning
+              service: processor
+            annotations:
+              summary: "Job failure rate exceeds 5%"
+              description: "The job failure rate has been above 5% for the last 2 minutes."
+
+          # Gateway High Latency (demo-friendly threshold)
+          - alert: GatewayHighLatency
+            expr: histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="gateway"}[5m])) > 1
+            for: 5m
+            labels:
+              severity: warning
+              service: gateway
+            annotations:
+              summary: "Gateway p95 latency > 1s"
+              description: "The gateway service p95 latency has exceeded 1 second."
+
+          # RabbitMQ Queue Growing (if metrics available)
+          - alert: QueueBacklogGrowing
+            expr: rabbitmq_queue_messages{queue="jobs.created"} > 100
+            for: 5m
+            labels:
+              severity: warning
+              service: rabbitmq
+            annotations:
+              summary: "RabbitMQ queue backlog growing"
+              description: "The jobs.created queue has more than 100 pending messages."

--- a/infra/k8s/prometheus.yaml
+++ b/infra/k8s/prometheus.yaml
@@ -33,6 +33,15 @@ data:
   prometheus.yml: |
     global:
       scrape_interval: 15s
+    
+    rule_files:
+      - /etc/prometheus/rules/*.yml
+    
+    alerting:
+      alertmanagers:
+        - static_configs:
+            - targets: ['alertmanager:9093']
+    
     scrape_configs:
       # Scrape Gateway
       - job_name: 'gateway'
@@ -76,12 +85,17 @@ spec:
         volumeMounts:
           - name: config-volume
             mountPath: /etc/prometheus
+          - name: rules-volume
+            mountPath: /etc/prometheus/rules
           - name: storage-volume
             mountPath: /prometheus
       volumes:
         - name: config-volume
           configMap:
             name: prometheus-config
+        - name: rules-volume
+          configMap:
+            name: prometheus-rules
         - name: storage-volume
           emptyDir: {}
 ---

--- a/infra/k8s/redisinsight.yaml
+++ b/infra/k8s/redisinsight.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redisinsight
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redisinsight
+  template:
+    metadata:
+      labels:
+        app: redisinsight
+    spec:
+      containers:
+      - name: redisinsight
+        image: redislabs/redisinsight:latest
+        ports:
+          - containerPort: 8001
+        env:
+          - name: RITRUSTEDORIGINS
+            value: "http://localhost:8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redisinsight
+spec:
+  # ClusterIP only - access via port-forward
+  type: ClusterIP
+  selector:
+    app: redisinsight
+  ports:
+    - port: 8001
+      targetPort: 8001

--- a/src/interfaces/web/index.html
+++ b/src/interfaces/web/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,7 +11,7 @@
             padding: 0;
             box-sizing: border-box;
         }
-        
+
         body {
             font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
             background: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
@@ -18,140 +19,246 @@
             color: #fff;
             padding: 20px;
         }
-        
+
         .container {
-            max-width: 1200px;
+            max-width: 1400px;
             margin: 0 auto;
         }
-        
+
         header {
             text-align: center;
-            padding: 30px 0;
+            padding: 20px 0;
             background: rgba(255, 255, 255, 0.1);
             backdrop-filter: blur(10px);
             border-radius: 16px;
-            margin-bottom: 30px;
+            margin-bottom: 20px;
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
-        
+
         header h1 {
-            font-size: 2.5rem;
+            font-size: 2rem;
             background: linear-gradient(90deg, #00d4ff, #7b2ff7);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
         }
-        
+
+        .header-links {
+            margin-top: 10px;
+        }
+
+        .header-links a {
+            color: #00d4ff;
+            text-decoration: none;
+            margin: 0 10px;
+            padding: 5px 12px;
+            border: 1px solid #00d4ff;
+            border-radius: 20px;
+            font-size: 0.85rem;
+            transition: all 0.3s;
+        }
+
+        .header-links a:hover {
+            background: #00d4ff;
+            color: #0f0c29;
+        }
+
         .stats-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 20px;
-            margin-bottom: 30px;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 15px;
+            margin-bottom: 20px;
         }
-        
+
         .stat-card {
             background: rgba(255, 255, 255, 0.1);
             backdrop-filter: blur(10px);
-            border-radius: 16px;
-            padding: 25px;
+            border-radius: 12px;
+            padding: 20px;
             text-align: center;
             border: 1px solid rgba(255, 255, 255, 0.1);
             transition: transform 0.3s ease;
         }
-        
+
         .stat-card:hover {
-            transform: translateY(-5px);
+            transform: translateY(-3px);
         }
-        
+
         .stat-card .value {
-            font-size: 3rem;
+            font-size: 2.5rem;
             font-weight: bold;
-            margin-bottom: 10px;
+            margin-bottom: 8px;
         }
-        
+
         .stat-card .label {
-            font-size: 0.9rem;
+            font-size: 0.8rem;
             opacity: 0.8;
             text-transform: uppercase;
             letter-spacing: 1px;
         }
-        
-        .stat-card.total .value { color: #ffd700; }
-        .stat-card.completed .value { color: #00ff88; }
-        .stat-card.failed .value { color: #ff4757; }
-        
-        .jobs-section {
+
+        .stat-card.total .value {
+            color: #ffd700;
+        }
+
+        .stat-card.completed .value {
+            color: #00ff88;
+        }
+
+        .stat-card.failed .value {
+            color: #ff4757;
+        }
+
+        .stat-card.alerts .value {
+            color: #ff6b6b;
+        }
+
+        .main-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+
+        @media (max-width: 900px) {
+            .main-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .section {
             background: rgba(255, 255, 255, 0.1);
             backdrop-filter: blur(10px);
-            border-radius: 16px;
-            padding: 25px;
+            border-radius: 12px;
+            padding: 20px;
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
-        
-        .jobs-section h2 {
-            margin-bottom: 20px;
-            font-size: 1.5rem;
+
+        .section h2 {
+            margin-bottom: 15px;
+            font-size: 1.2rem;
         }
-        
+
         table {
             width: 100%;
             border-collapse: collapse;
+            font-size: 0.9rem;
         }
-        
-        th, td {
-            padding: 15px;
+
+        th,
+        td {
+            padding: 10px;
             text-align: left;
             border-bottom: 1px solid rgba(255, 255, 255, 0.1);
         }
-        
+
         th {
             color: #ffd700;
             font-weight: 600;
             text-transform: uppercase;
-            font-size: 0.85rem;
+            font-size: 0.75rem;
             letter-spacing: 1px;
         }
-        
+
         .status {
-            padding: 5px 12px;
-            border-radius: 20px;
-            font-size: 0.85rem;
+            padding: 4px 10px;
+            border-radius: 15px;
+            font-size: 0.8rem;
             font-weight: 600;
         }
-        
-        .status.COMPLETED { background: rgba(0, 255, 136, 0.2); color: #00ff88; }
-        .status.FAILED { background: rgba(255, 71, 87, 0.2); color: #ff4757; }
-        .status.PENDING { background: rgba(255, 215, 0, 0.2); color: #ffd700; }
-        
+
+        .status.COMPLETED {
+            background: rgba(0, 255, 136, 0.2);
+            color: #00ff88;
+        }
+
+        .status.FAILED {
+            background: rgba(255, 71, 87, 0.2);
+            color: #ff4757;
+        }
+
+        .status.PENDING {
+            background: rgba(255, 215, 0, 0.2);
+            color: #ffd700;
+        }
+
+        .alert-item {
+            background: rgba(255, 71, 87, 0.15);
+            border-left: 3px solid #ff4757;
+            padding: 10px 15px;
+            margin-bottom: 10px;
+            border-radius: 0 8px 8px 0;
+        }
+
+        .alert-item.warning {
+            background: rgba(255, 215, 0, 0.15);
+            border-left-color: #ffd700;
+        }
+
+        .alert-item .alert-name {
+            font-weight: 600;
+            color: #ff6b6b;
+        }
+
+        .alert-item.warning .alert-name {
+            color: #ffd700;
+        }
+
+        .alert-item .alert-service {
+            font-size: 0.85rem;
+            opacity: 0.8;
+        }
+
+        .no-alerts {
+            text-align: center;
+            padding: 20px;
+            opacity: 0.6;
+            color: #00ff88;
+        }
+
         .last-update {
             text-align: center;
             opacity: 0.6;
-            margin-top: 20px;
-            font-size: 0.9rem;
+            margin-top: 15px;
+            font-size: 0.85rem;
         }
-        
+
         @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
+
+            0%,
+            100% {
+                opacity: 1;
+            }
+
+            50% {
+                opacity: 0.5;
+            }
         }
-        
+
         .live-indicator {
             display: inline-block;
-            width: 10px;
-            height: 10px;
+            width: 8px;
+            height: 8px;
             background: #00ff88;
             border-radius: 50%;
-            margin-right: 8px;
+            margin-right: 6px;
             animation: pulse 2s infinite;
         }
     </style>
 </head>
+
 <body>
     <div class="container">
         <header>
             <h1>📡 Distributed Task Observatory</h1>
-            <p style="margin-top: 10px; opacity: 0.8;"><span class="live-indicator"></span>Live Dashboard</p>
+            <p style="margin-top: 8px; opacity: 0.8; font-size: 0.9rem;"><span class="live-indicator"></span>Live
+                Dashboard</p>
+            <div class="header-links">
+                <a href="http://grafana.local" target="_blank">📊 Grafana</a>
+                <a href="http://prometheus.local" target="_blank">📈 Prometheus</a>
+                <a href="http://rabbitmq.local" target="_blank">🐰 RabbitMQ</a>
+            </div>
         </header>
-        
+
         <div class="stats-grid">
             <div class="stat-card total">
                 <div class="value" id="totalJobs">-</div>
@@ -165,40 +272,77 @@
                 <div class="value" id="failedJobs">-</div>
                 <div class="label">Failed</div>
             </div>
+            <div class="stat-card alerts">
+                <div class="value" id="alertCount">0</div>
+                <div class="label">Active Alerts</div>
+            </div>
         </div>
-        
-        <div class="jobs-section">
-            <h2>📋 Recent Jobs</h2>
+
+        <div class="main-grid">
+            <div class="section">
+                <h2>📋 Recent Jobs</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Type</th>
+                            <th>Status</th>
+                            <th>Created</th>
+                        </tr>
+                    </thead>
+                    <tbody id="jobsTable">
+                        <tr>
+                            <td colspan="4" style="text-align: center;">Loading...</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="section">
+                <h2>🚨 Active Alerts</h2>
+                <div id="alertsContainer">
+                    <div class="no-alerts">✓ No active alerts</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>📜 Raw Events (MongoDB)</h2>
             <table>
                 <thead>
                     <tr>
-                        <th>ID</th>
+                        <th>Event ID</th>
                         <th>Type</th>
-                        <th>Status</th>
-                        <th>Created</th>
+                        <th>Occurred At</th>
+                        <th>Job ID</th>
                     </tr>
                 </thead>
-                <tbody id="jobsTable">
-                    <tr><td colspan="4" style="text-align: center;">Loading...</td></tr>
+                <tbody id="eventsTable">
+                    <tr>
+                        <td colspan="4" style="text-align: center;">Loading...</td>
+                    </tr>
                 </tbody>
             </table>
         </div>
-        
+
         <div class="last-update">
             Last updated: <span id="lastUpdate">-</span>
         </div>
     </div>
-    
+
     <script>
-        const API_URL = window.location.hostname === 'localhost' 
-            ? 'http://localhost:8080' 
+        const API_URL = window.location.hostname === 'localhost'
+            ? 'http://localhost:8080'
             : '/api';
-        
+        const GATEWAY_URL = window.location.hostname === 'localhost'
+            ? 'http://localhost:3000'
+            : '/gateway';
+
         async function fetchStats() {
             try {
                 const response = await fetch(`${API_URL}/stats`);
                 const stats = await response.json();
-                
+
                 document.getElementById('totalJobs').textContent = stats.totalJobs || 0;
                 document.getElementById('completedJobs').textContent = stats.completedJobs || 0;
                 document.getElementById('failedJobs').textContent = stats.failedJobs || 0;
@@ -206,20 +350,20 @@
                 console.error('Failed to fetch stats:', error);
             }
         }
-        
+
         async function fetchJobs() {
             try {
                 const response = await fetch(`${API_URL}/jobs/recent`);
                 const jobs = await response.json();
-                
+
                 const tbody = document.getElementById('jobsTable');
                 if (jobs && jobs.length > 0) {
-                    tbody.innerHTML = jobs.map(job => `
+                    tbody.innerHTML = jobs.slice(0, 5).map(job => `
                         <tr>
                             <td><code>${job.id.substring(0, 8)}...</code></td>
                             <td>${job.type}</td>
                             <td><span class="status ${job.status}">${job.status}</span></td>
-                            <td>${new Date(job.createdAt).toLocaleString()}</td>
+                            <td>${new Date(job.createdAt).toLocaleTimeString()}</td>
                         </tr>
                     `).join('');
                 } else {
@@ -229,21 +373,98 @@
                 console.error('Failed to fetch jobs:', error);
             }
         }
-        
+
+        async function fetchAlerts() {
+            try {
+                const response = await fetch(`${GATEWAY_URL}/proxy/alerts`);
+                const alerts = await response.json();
+
+                const container = document.getElementById('alertsContainer');
+                const countEl = document.getElementById('alertCount');
+
+                if (alerts && alerts.length > 0) {
+                    countEl.textContent = alerts.length;
+                    container.innerHTML = alerts.map(alert => {
+                        const severity = alert.labels?.severity || 'warning';
+                        const name = alert.labels?.alertname || 'Unknown';
+                        const service = alert.labels?.service || '-';
+                        return `
+                            <div class="alert-item ${severity}">
+                                <div class="alert-name">${name}</div>
+                                <div class="alert-service">Service: ${service}</div>
+                            </div>
+                        `;
+                    }).join('');
+                } else {
+                    countEl.textContent = '0';
+                    container.innerHTML = '<div class="no-alerts">✓ No active alerts</div>';
+                }
+            } catch (error) {
+                document.getElementById('alertCount').textContent = '-';
+                document.getElementById('alertsContainer').innerHTML =
+                    '<div class="no-alerts" style="color: #ffd700;">⚠ Could not fetch alerts</div>';
+            }
+        }
+
+        async function fetchEvents() {
+            try {
+                const response = await fetch(`${API_URL}/events`);
+                const events = await response.json();
+
+                const tbody = document.getElementById('eventsTable');
+                if (events && events.length > 0) {
+                    // Handle BSON-style or regular JSON
+                    tbody.innerHTML = events.slice(0, 5).map(event => {
+                        let eventId = event.eventid || event.eventId || '-';
+                        let eventType = event.eventtype || event.eventType || '-';
+                        let occurredAt = event.occurredat || event.occurredAt || '-';
+                        let jobId = '-';
+
+                        // Try to extract job ID from payload
+                        if (event.payload) {
+                            if (Array.isArray(event.payload)) {
+                                const idField = event.payload.find(p => p.Key === 'id');
+                                if (idField) jobId = idField.Value;
+                            } else if (event.payload.id) {
+                                jobId = event.payload.id;
+                            }
+                        }
+
+                        if (eventId.length > 8) eventId = eventId.substring(0, 8) + '...';
+                        if (jobId.length > 8) jobId = jobId.substring(0, 8) + '...';
+
+                        return `
+                            <tr>
+                                <td><code>${eventId}</code></td>
+                                <td>${eventType}</td>
+                                <td>${new Date(occurredAt).toLocaleTimeString()}</td>
+                                <td><code>${jobId}</code></td>
+                            </tr>
+                        `;
+                    }).join('');
+                } else {
+                    tbody.innerHTML = '<tr><td colspan="4" style="text-align: center;">No events yet</td></tr>';
+                }
+            } catch (error) {
+                console.error('Failed to fetch events:', error);
+            }
+        }
+
         function updateTimestamp() {
             document.getElementById('lastUpdate').textContent = new Date().toLocaleTimeString();
         }
-        
+
         async function refresh() {
-            await Promise.all([fetchStats(), fetchJobs()]);
+            await Promise.all([fetchStats(), fetchJobs(), fetchAlerts(), fetchEvents()]);
             updateTimestamp();
         }
-        
+
         // Initial load
         refresh();
-        
-        // Auto-refresh every 3 seconds
-        setInterval(refresh, 3000);
+
+        // Auto-refresh every 5 seconds
+        setInterval(refresh, 5000);
     </script>
 </body>
+
 </html>


### PR DESCRIPTION
- Gateway: Add /proxy/alerts and /proxy/targets endpoints (5s timeout)
- Alertmanager: Add config with routing, grouping, webhook sink
- Prometheus: Add alerting rules with divide-by-zero guards
  - ServiceDown, JobFailureRateHigh, GatewayHighLatency, QueueBacklogGrowing
- RedisInsight: Add deployment (ClusterIP only, dev access)
- Web UI: Add alerts card, raw events section, Grafana/Prometheus links
- TUI: Add alerts pane with bounded retries (max 3) and graceful degradation