### PR TITLE
feat(release): use semantic-release-action for reliable version detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,24 +4,20 @@ on:
   push:
     branches:
       - main
-  # Also support manual tag triggers for hotfixes
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (e.g., 0.1.0)'
-        required: true
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Determine version via semantic-release (dry-run first)
-  version:
+  # Run semantic-release to determine if release is needed
+  release:
     runs-on: ubuntu-latest
     outputs:
       new_release: ${{ steps.semantic.outputs.new_release_published }}
       version: ${{ steps.semantic.outputs.new_release_version }}
       tag: ${{ steps.semantic.outputs.new_release_git_tag }}
+    
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,30 +29,26 @@ jobs:
         with:
           node-version: '20'
       
-      - name: Install semantic-release
-        run: npm install -g semantic-release @semantic-release/exec @semantic-release/git
-      
-      - name: Semantic Release (dry-run)
+      - name: Semantic Release
         id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/exec
+            @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Release info
+        if: steps.semantic.outputs.new_release_published == 'true'
         run: |
-          OUTPUT=$(npx semantic-release --dry-run 2>&1) || true
-          echo "$OUTPUT"
-          
-          if echo "$OUTPUT" | grep -q "Published release"; then
-            VERSION=$(echo "$OUTPUT" | grep -oP "Published release \K[0-9]+\.[0-9]+\.[0-9]+")
-            echo "new_release_published=true" >> $GITHUB_OUTPUT
-            echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
-            echo "new_release_git_tag=v$VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "new_release_published=false" >> $GITHUB_OUTPUT
-          fi
+          echo "New release: v${{ steps.semantic.outputs.new_release_version }}"
+          echo "Git tag: ${{ steps.semantic.outputs.new_release_git_tag }}"
 
   # Build binaries for all platforms (only if new release)
   build:
-    needs: version
-    if: needs.version.outputs.new_release == 'true'
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -94,44 +86,29 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       
-      - name: Install cross-compilation tools (Linux ARM64)
+      - name: Install cross (for ARM Linux)
         if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+      
+      - name: Build binary
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-      
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src/interfaces/tui/target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-
-      
-      - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
-        working-directory: src/interfaces/tui
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-      
-      - name: Rename binary to canonical name
+          cd src/interfaces/tui
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} --locked
+          else
+            cargo build --release --target ${{ matrix.target }} --locked
+          fi
         shell: bash
-        run: |
-          cp src/interfaces/tui/target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.artifact }}
       
-      - name: Smoke test (native platforms only)
-        if: ${{ !matrix.cross }}
-        shell: bash
+      - name: Rename artifact
         run: |
-          ./${{ matrix.artifact }} --version
-          ./${{ matrix.artifact }} --help
+          cd src/interfaces/tui/target/${{ matrix.target }}/release
+          cp ${{ matrix.binary }} ${{ github.workspace }}/${{ matrix.artifact }}
+        shell: bash
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -142,7 +119,7 @@ jobs:
 
   # Generate checksums
   checksums:
-    needs: build
+    needs: [release, build]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -153,10 +130,8 @@ jobs:
       - name: Generate SHA256SUMS
         run: |
           cd artifacts
-          # Move all binaries to current directory
           find . -type f -name "odd-dashboard-*" -exec mv {} . \;
-          
-          # Generate checksums (GNU format: hash  filename)
+          rm -rf odd-dashboard-*/
           sha256sum odd-dashboard-* > SHA256SUMS
           
           echo "SHA256SUMS contents:"
@@ -169,9 +144,9 @@ jobs:
           path: artifacts/SHA256SUMS
           retention-days: 1
 
-  # Create GitHub Release
-  release:
-    needs: [version, build, checksums]
+  # Upload assets to GitHub Release
+  upload-assets:
+    needs: [release, build, checksums]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -208,13 +183,10 @@ jobs:
           done
           echo "All expected artifacts present"
       
-      - name: Create Release
+      - name: Upload assets to release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
+          tag_name: ${{ needs.release.outputs.tag }}
           files: release/*
           body: |
             ## ⚠️ Bootstrap Release (Unsigned)
@@ -253,7 +225,7 @@ jobs:
 
   # Publish npm package
   npm-publish:
-    needs: [version, release]
+    needs: [release, upload-assets]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -267,7 +239,7 @@ jobs:
       - name: Update npm package version
         run: |
           cd packages/npm-shim
-          npm version ${{ needs.version.outputs.version }} --no-git-tag-version --allow-same-version
+          npm version ${{ needs.release.outputs.version }} --no-git-tag-version --allow-same-version
       
       - name: Publish to npm
         run: |
@@ -275,28 +247,3 @@ jobs:
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  # Finalize: run semantic-release to create tag and commit VERSION update
-  finalize:
-    needs: [version, npm-publish]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      
-      - name: Install semantic-release
-        run: npm install -g semantic-release @semantic-release/exec @semantic-release/git
-      
-      - name: Run semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release


### PR DESCRIPTION
The manual dry-run parsing with grep was fragile and didn't reliably detect new releases. Switch to cycjimmy/semantic-release-action which provides clean outputs for version detection.

Changes:
- Use cycjimmy/semantic-release-action@v4 instead of manual npx
- Rename jobs for clarity (version -> release, release -> upload-assets)
- Add --locked flag to cargo build for reproducible builds
- Simplify workflow structure