### PR TITLE
feat(ci): add release permissions and dry-run validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,34 @@ jobs:
           cargo test --locked
 
   # ============================================================
+  # Release Dry-Run - Catches semantic-release config issues before merge
+  # ============================================================
+  release-dry-run:
+    name: Release Dry-Run
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Semantic Release (dry-run)
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          dry_run: true
+          extra_plugins: |
+            @semantic-release/exec
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ============================================================
   # Container Image Builds (Future extensibility)
   # ============================================================
   # docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
   # Run semantic-release to determine if release is needed
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     outputs:
       new_release: ${{ steps.semantic.outputs.new_release_published }}
       version: ${{ steps.semantic.outputs.new_release_version }}
@@ -22,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
       
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Release workflow was failing with EGITNOPERMISSION because:
- Missing contents:write permission for pushing tags
- persist-credentials:false prevented token from being used

Fixes:
- Add permissions block (contents, issues, pull-requests: write)
- Set persist-credentials: true on checkout
- Add release-dry-run job to CI to catch config issues before merge