### PR TITLE
fix(release): restore @semantic-release/github plugin

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,6 +22,12 @@
                 ],
                 "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }
+        ],
+        [
+            "@semantic-release/github",
+            {
+                "assets": []
+            }
         ]
     ]
 }


### PR DESCRIPTION
This plugin creates the GitHub Release. Without it, releases only created git tags but no actual GitHub Release was published.