### PR TITLE
fix(release): let workflow create GitHub release with binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,10 +223,12 @@ jobs:
         with:
           tag_name: ${{ needs.release.outputs.tag }}
           files: release/*
+          generate_release_notes: true
+          append_body: true
           body: |
             ## ⚠️ Bootstrap Release (Unsigned)
             
-            This is a **v0.1.x bootstrap release**. Binaries are NOT code-signed.
+            Binaries are NOT code-signed.
             - Your OS may show security prompts — this is expected.
             - Verify integrity via SHA256 checksums (see below).
             - Signing will be introduced in a future release.

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,12 +22,6 @@
                 ],
                 "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }
-        ],
-        [
-            "@semantic-release/github",
-            {
-                "assets": []
-            }
         ]
     ]
 }


### PR DESCRIPTION
Root cause: @semantic-release/github created empty releases before binaries were built, resulting in source-only releases.

Fix:
- Remove @semantic-release/github plugin from .releaserc.json
- Let softprops/action-gh-release in upload-assets job create the release after all binaries are built and ready
- Add generate_release_notes for auto-generated changelog
- Add append_body to include installation instructions

This ensures GitHub releases include all binary artifacts.