### PR TITLE
fix(release): handle artifact directory structure from download-artif…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,11 +164,20 @@ jobs:
       - name: Generate SHA256SUMS
         run: |
           cd artifacts
-          find . -type f -name "odd-dashboard-*" -exec mv {} . \;
-          rm -rf odd-dashboard-*/
+          # download-artifact@v4 creates subdirectories for each artifact
+          # Move files to flat structure
+          find . -mindepth 2 -type f -exec mv {} . \;
+          # Remove empty directories
+          find . -type d -empty -delete
+          
+          # List what we have
+          echo "=== Artifacts ==="
+          ls -la
+          
+          # Generate checksums
           sha256sum odd-dashboard-* > SHA256SUMS
           
-          echo "SHA256SUMS contents:"
+          echo "=== SHA256SUMS contents ==="
           cat SHA256SUMS
       
       - name: Upload checksums


### PR DESCRIPTION
…act@v4

The download-artifact@v4 action creates a subdirectory for each artifact (e.g., artifacts/odd-dashboard-linux-x64/odd-dashboard-linux-x64).

Fix:
- Use 'find . -mindepth 2 -type f' to find files in subdirectories
- Move them to flat structure before generating checksums
- Add debug output to show what artifacts are present