### PR TITLE
feat(tui): capture install output in log panel instead of breaking TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,14 +401,17 @@ jobs:
           go test -coverprofile=coverage.out ./...
           go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//' | xargs -I{} bash -c 'if (( $(echo "{} < 3" | bc -l) )); then echo "Coverage {}% below 3% threshold"; exit 1; fi'
 
-      # Rust TUI - cargo test (coverage via tarpaulin optional)
+      # Rust TUI - cargo test with tarpaulin coverage - HARD FAIL below threshold
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Rust TUI tests - HARD FAIL
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Rust TUI tests with coverage - HARD FAIL below 14%
         run: |
           cd src/interfaces/tui
-          cargo test
+          cargo tarpaulin --out Xml --skip-clean --timeout 120 --fail-under 14
 
   # ============================================================
   # Lint & Format (polyglot)

--- a/src/interfaces/tui/src/install.rs
+++ b/src/interfaces/tui/src/install.rs
@@ -9,12 +9,22 @@ use arboard::Clipboard;
 use crate::types::{Prerequisite, PrereqStatus};
 use crate::error::get_install_command;
 
-/// Result of an installation attempt
+/// Result of an installation attempt with captured output
 #[derive(Debug, Clone)]
-pub enum InstallResult {
-    Success,
-    Failed(String),
-    Skipped,
+pub struct InstallOutput {
+    pub success: bool,
+    pub lines: Vec<String>,
+    pub error_message: Option<String>,
+}
+
+impl Default for InstallOutput {
+    fn default() -> Self {
+        Self {
+            success: false,
+            lines: Vec::new(),
+            error_message: None,
+        }
+    }
 }
 
 /// Copy install command to clipboard
@@ -31,64 +41,107 @@ pub fn copy_to_clipboard(prereq_name: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Execute an install command for a prerequisite
+/// Execute an install command and capture output
 /// 
-/// # Safety
-/// This executes shell commands on the user's system. The commands are
-/// platform-specific and come from the error module's install step functions.
-pub fn execute_install(prereq_name: &str) -> InstallResult {
+/// Returns captured stdout/stderr lines for display in TUI
+pub fn execute_install_with_output(prereq_name: &str) -> InstallOutput {
     let cmd = match get_install_command(prereq_name) {
         Some(c) => c,
-        None => return InstallResult::Failed(format!("No install command for {}", prereq_name)),
+        None => return InstallOutput {
+            success: false,
+            lines: vec![format!("No install command for {}", prereq_name)],
+            error_message: Some(format!("Unknown prerequisite: {}", prereq_name)),
+        },
     };
     
     // Execute the command based on platform
     #[cfg(target_os = "windows")]
     {
-        execute_windows_command(&cmd)
+        execute_windows_command_captured(&cmd)
     }
     
     #[cfg(target_os = "macos")]
     {
-        execute_unix_command(&cmd, "zsh")
+        execute_unix_command_captured(&cmd, "zsh")
     }
     
     #[cfg(target_os = "linux")]
     {
-        execute_unix_command(&cmd, "bash")
+        execute_unix_command_captured(&cmd, "bash")
     }
 }
 
 #[cfg(target_os = "windows")]
-fn execute_windows_command(cmd: &str) -> InstallResult {
-    // Use PowerShell to execute the command
+fn execute_windows_command_captured(cmd: &str) -> InstallOutput {
     let result = Command::new("powershell.exe")
         .args(["-NoProfile", "-Command", cmd])
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status();
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output();
     
     match result {
-        Ok(status) if status.success() => InstallResult::Success,
-        Ok(status) => InstallResult::Failed(format!("Command exited with code: {:?}", status.code())),
-        Err(e) => InstallResult::Failed(format!("Failed to execute: {}", e)),
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            
+            let mut lines: Vec<String> = stdout.lines().map(|s| s.to_string()).collect();
+            lines.extend(stderr.lines().map(|s| format!("ERR: {}", s)));
+            
+            // Keep last 20 lines to avoid overwhelming the display
+            if lines.len() > 20 {
+                lines = lines.into_iter().rev().take(20).rev().collect();
+            }
+            
+            InstallOutput {
+                success: output.status.success(),
+                lines,
+                error_message: if output.status.success() { None } else {
+                    Some(format!("Exit code: {:?}", output.status.code()))
+                },
+            }
+        }
+        Err(e) => InstallOutput {
+            success: false,
+            lines: vec![format!("Failed to execute: {}", e)],
+            error_message: Some(e.to_string()),
+        },
     }
 }
 
 #[cfg(not(target_os = "windows"))]
-fn execute_unix_command(cmd: &str, shell: &str) -> InstallResult {
+fn execute_unix_command_captured(cmd: &str, shell: &str) -> InstallOutput {
     let result = Command::new(shell)
         .args(["-c", cmd])
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status();
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output();
     
     match result {
-        Ok(status) if status.success() => InstallResult::Success,
-        Ok(status) => InstallResult::Failed(format!("Command exited with code: {:?}", status.code())),
-        Err(e) => InstallResult::Failed(format!("Failed to execute: {}", e)),
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            
+            let mut lines: Vec<String> = stdout.lines().map(|s| s.to_string()).collect();
+            lines.extend(stderr.lines().map(|s| format!("ERR: {}", s)));
+            
+            // Keep last 20 lines to avoid overwhelming the display
+            if lines.len() > 20 {
+                lines = lines.into_iter().rev().take(20).rev().collect();
+            }
+            
+            InstallOutput {
+                success: output.status.success(),
+                lines,
+                error_message: if output.status.success() { None } else {
+                    Some(format!("Exit code: {:?}", output.status.code()))
+                },
+            }
+        }
+        Err(e) => InstallOutput {
+            success: false,
+            lines: vec![format!("Failed to execute: {}", e)],
+            error_message: Some(e.to_string()),
+        },
     }
 }
 
@@ -107,32 +160,161 @@ pub fn get_install_description(prereq_name: &str) -> String {
 mod tests {
     use super::*;
 
+    // ========== InstallOutput Tests ==========
+    
     #[test]
-    fn test_install_result_variants() {
-        let success = InstallResult::Success;
-        let failed = InstallResult::Failed("error".to_string());
-        let skipped = InstallResult::Skipped;
-        
-        assert!(matches!(success, InstallResult::Success));
-        assert!(matches!(failed, InstallResult::Failed(_)));
-        assert!(matches!(skipped, InstallResult::Skipped));
+    fn test_install_output_default() {
+        let output = InstallOutput::default();
+        assert!(!output.success);
+        assert!(output.lines.is_empty());
+        assert!(output.error_message.is_none());
     }
 
     #[test]
-    fn test_get_install_description() {
-        let docker_desc = get_install_description("docker");
-        assert!(docker_desc.contains("Docker"));
-        
-        let kubectl_desc = get_install_description("kubectl");
-        assert!(kubectl_desc.contains("kubectl"));
-        
-        let unknown_desc = get_install_description("unknown_tool");
-        assert!(unknown_desc.contains("prerequisite"));
+    fn test_install_output_with_lines() {
+        let output = InstallOutput {
+            success: true,
+            lines: vec!["Line 1".to_string(), "Line 2".to_string()],
+            error_message: None,
+        };
+        assert!(output.success);
+        assert_eq!(output.lines.len(), 2);
+        assert_eq!(output.lines[0], "Line 1");
+        assert_eq!(output.lines[1], "Line 2");
     }
+
+    #[test]
+    fn test_install_output_with_error() {
+        let output = InstallOutput {
+            success: false,
+            lines: vec!["ERR: Something went wrong".to_string()],
+            error_message: Some("Exit code: 1".to_string()),
+        };
+        assert!(!output.success);
+        assert!(output.lines[0].starts_with("ERR:"));
+        assert!(output.error_message.is_some());
+        assert!(output.error_message.unwrap().contains("Exit code"));
+    }
+
+    #[test]
+    fn test_install_output_empty_lines() {
+        let output = InstallOutput {
+            success: true,
+            lines: vec![],
+            error_message: None,
+        };
+        assert!(output.success);
+        assert!(output.lines.is_empty());
+    }
+
+    #[test]
+    fn test_install_output_clone() {
+        let output = InstallOutput {
+            success: true,
+            lines: vec!["test".to_string()],
+            error_message: Some("error".to_string()),
+        };
+        let cloned = output.clone();
+        assert_eq!(cloned.success, output.success);
+        assert_eq!(cloned.lines, output.lines);
+        assert_eq!(cloned.error_message, output.error_message);
+    }
+
+    // ========== execute_install_with_output Tests ==========
+
+    #[test]
+    fn test_execute_install_unknown_prereq() {
+        let output = execute_install_with_output("nonexistent_tool_xyz");
+        assert!(!output.success);
+        assert!(!output.lines.is_empty());
+        assert!(output.lines[0].contains("No install command"));
+        assert!(output.error_message.is_some());
+    }
+
+    #[test]
+    fn test_execute_install_returns_output_structure() {
+        // Test with unknown tool - fast and verifies structure without running actual install
+        let output = execute_install_with_output("nonexistent_prereq_xyz");
+        // Verify InstallOutput structure fields are accessible
+        let _ = output.success;
+        let _ = output.lines.len();
+        let _ = output.error_message.is_some();
+        // For unknown tools, should always have at least one line of output
+        assert!(!output.lines.is_empty());
+    }
+
+    // ========== get_install_description Tests ==========
+
+    #[test]
+    fn test_get_install_description_docker() {
+        let desc = get_install_description("docker");
+        assert!(desc.contains("Docker"));
+        assert!(desc.contains("container"));
+    }
+
+    #[test]
+    fn test_get_install_description_docker_desktop() {
+        let desc = get_install_description("Docker Desktop");
+        assert!(desc.contains("Docker"));
+    }
+
+    #[test]
+    fn test_get_install_description_powershell() {
+        let desc = get_install_description("powershell");
+        assert!(desc.contains("PowerShell"));
+    }
+
+    #[test]
+    fn test_get_install_description_pwsh() {
+        let desc = get_install_description("pwsh");
+        assert!(desc.contains("PowerShell"));
+    }
+
+    #[test]
+    fn test_get_install_description_kubectl() {
+        let desc = get_install_description("kubectl");
+        assert!(desc.contains("kubectl"));
+        assert!(desc.contains("Kubernetes"));
+    }
+
+    #[test]
+    fn test_get_install_description_kind() {
+        let desc = get_install_description("kind");
+        assert!(desc.contains("kind"));
+        assert!(desc.contains("Docker") || desc.contains("Kubernetes"));
+    }
+
+    #[test]
+    fn test_get_install_description_unknown() {
+        let desc = get_install_description("unknown_tool_xyz");
+        assert!(desc.contains("prerequisite"));
+        assert!(desc.contains("unknown_tool_xyz"));
+    }
+
+    #[test]
+    fn test_get_install_description_case_insensitive() {
+        let lower = get_install_description("docker");
+        let upper = get_install_description("DOCKER");
+        let mixed = get_install_description("Docker");
+        assert_eq!(lower, upper);
+        assert_eq!(lower, mixed);
+    }
+
+    // ========== copy_to_clipboard Tests ==========
 
     #[test]
     fn test_copy_to_clipboard_unknown_tool() {
         let result = copy_to_clipboard("nonexistent_tool_xyz");
         assert!(result.is_err());
+        assert!(result.unwrap_err().contains("No install command"));
+    }
+
+    #[test]
+    fn test_copy_to_clipboard_valid_tool_returns_result() {
+        // This will succeed or fail based on clipboard availability
+        // We just verify it returns a Result
+        let result = copy_to_clipboard("docker");
+        // Don't assert success/failure - depends on environment
+        assert!(result.is_ok() || result.is_err());
     }
 }

--- a/src/interfaces/tui/src/lib.rs
+++ b/src/interfaces/tui/src/lib.rs
@@ -43,6 +43,6 @@ pub use cluster::{
 };
 
 pub use install::{
-    InstallResult,
-    copy_to_clipboard, execute_install, get_install_description,
+    InstallOutput,
+    copy_to_clipboard, execute_install_with_output, get_install_description,
 };


### PR DESCRIPTION
- Replace Stdio::inherit() with Stdio::piped() to capture output
- New InstallOutput struct with success, lines, and error_message
- Display last 8 output lines in Prerequisites view
- Color-code ERR: lines in red, normal output in gray
- Truncate long lines to 60 chars for display
- Add is_installing state to track execution progress