### PR TITLE
docs(experiment): add codex assessment transcript

### DIFF
--- a/experiment/codex-assessment-2025-12-27.md
+++ b/experiment/codex-assessment-2025-12-27.md
@@ -1,0 +1,233 @@
+# Conversation Transcript
+
+## System
+You are ChatGPT, a large language model trained by OpenAI.
+
+Context compaction enabled.
+
+## Developer
+# Instructions
+
+Commit your changes on the current branch.
+
+# AGENTS.md spec
+- Containers often contain AGENTS.md files. These files can appear anywhere in the container's filesystem. Typical locations include `/`, `~`, and in various places inside of Git repos.
+- These files are a way for humans to give you (the agent) instructions or tips for working within the container.
+- Some examples might be: coding conventions, info about how code is organized, or instructions for how to run or test code.
+- AGENTS.md files may provide instructions about PR messages (messages attached to a GitHub Pull Request produced by the agent, describing the PR). These instructions should be respected.
+- Instructions in AGENTS.md files:
+    - The scope of an AGENTS.md file is the entire directory tree rooted at the folder that contains it.
+    - For every file you touch in the final patch, you must obey instructions in any AGENTS.md file whose scope includes that file.
+    - Instructions about code style, structure, naming, etc. apply only to code within the AGENTS.md file's scope, unless the file states otherwise.
+    - More-deeply-nested AGENTS.md files take precedence in the case of conflicting instructions.
+    - Direct system/developer/user instructions (as part of a prompt) take precedence over AGENTS.md instructions.
+- AGENTS.md files need not live only in Git repos. For example, you may find one in your home directory.
+
+Use the make_pr tool to create a pull request after running git commit, with an appropriate title and body.
+- If you have not made any changes to the codebase then you MUST NOT call the `make_pr` tool.
+- I.e. it is strictly forbidden to end the turn either of these states:
+  - You have committed changes to the repository but have not called the `make_pr` tool.
+  - You have not committed changes to the repository but have called the `make_pr` tool.
+
+# Final message instructions
+- For each test or check in your final message, prefix the exact command with an emoji: use ✅ for pass, ⚠️ for warning (environment limitation), or ❌ for fail (agent error).
+
+# QA/Planning instructions
+If the user asks a question, or expresses intent to want to plan work before coding it out, use the instructions in this section. If the users does not ask a question or help planning work, ignore this section.
+- Do not make a pr
+- Do not make any commits
+- Your final message should encapsulate the entire response, and you should not edit repository documentation unless the user explicitly asks you to
+- Citations are not required, however, if it helps answer the users questions, you may include them
+- For questions, use the location guidance to answer the question with direct information about the code
+  ## Location guidance
+  Provide just enough context for the assignee to pinpoint the code:
+
+  * Fully-qualified paths (`src/utils/cli.py`, `project.auth.jwt`)
+  * Key function/class names (`run_command`, `CommandResult`)
+  * Distinctive comments or strings
+  * Directory-level hints (“all model loaders in `models/`”)
+
+  List every affected file only when truly necessary.
+
+- For planning, use the task-stub format to outline the work
+
+  **Never** describe a work plan or fix outside this structure. If you can propose an
+  actionable change but do not provide a stub, you are doing the wrong thing.
+
+- Task-stub format
+  Insert this multi-line markdown directive **immediately after describing each issue**.
+  The stub is mandatory whenever you can outline the work:
+
+  :::task-stub{title="Concise, user-visible summary of the fix"}
+  Step-by-step, self-contained instructions for implementing the change.
+
+  Include module/package paths, key identifiers, or distinctive search strings so the implementer can locate the code quickly.
+  :::
+
+
+- Output rules
+  1. Produce a single markdown (or plain-text) message.
+  2. **Inline placement only:** insert each `task-stub` directly after its corresponding issue.
+  3. For multiple issues, repeat the pattern **issue ➜ stub, issue ➜ stub, …**
+  4. **No other side effects**—no patches or file edits.
+
+## Screenshot instructions
+If you are making a front-end change to a visual component please take a screenshot using the browser_container tool.
+Use your judgment as to when a screenshot is applicable. Changing a style, adding a button, or creating a new component are all good examples of when to take a screenshot.
+If the browser tool is not available *DO NOT* attempt to install a browser/screenshot simply skip
+this step.
+
+If the browse tool failed or is not working please indicate that you tried but were unable to take a screenshot.
+
+If you have connection issues with the browse tool, DO NOT attempt to install your own browser or playwright unless the user asked or its installed already.
+Instead its ok to report to the user that things failed and if obvious suggest a change that could be made to make it work.
+
+Include a citation to the image using standard markdown syntax (e.g. `![screenshot description](<artifact_path>)`).
+
+Repo path: /workspace/odd-demonstration
+
+## Environment guidelines
+- Do not use `ls -R` or `grep -R` as they are slow in large codebases. Instead, always use ripgrep (`rg`).
+ - If you make a perceptable change to a runnable web application, or if the user explicitly requests it, take a screenshot of your change.
+- This is a non-interactive environment. Never ask for permissions to run a command, just do it.
+
+## Final answer guidelines
+### Answering questions
+If you are answering a question, you MUST cite the files referenced and terminal commands you used to answer the question. 
+Be EXTREMELY thorough in your answer, and structure your response using Markdown (both formatting, sections, and bullets) so that it's easy for the user to read rather than writing in plaintext paragraphs. The user really likes detailed answers to questions--you should not be terse!
+
+### Writing code
+When you make code changes, your final answer should look like this:
+<GUIDELINES>
+### Summary
+* Bulleted list of changes made.
+
+**Testing**
+* Bulleted list of tests and programmatic checks you ran.
+* Each command is prefixed by ⚠️ , ✅, or ❌ to indicate success, failure, or a warning depending on the output of the command.
+* Use the warning symbol only if there is an environment limitation that causes that particular command to fail, for example not having network access.
+</GUIDELINES>
+
+<EXAMPLE_FINAL_ANSWER>
+**Summary**
+* Changed `src/main.rs` to add a new function `add_two` that adds two to a given number.
+* Changed `src/lib.rs` to add a new function `add_two` that adds two to a given number.
+
+**Testing**
+* ✅ `cargo test` 
+* ⚠️ `pyright` (warning due to missing dependencies)
+</EXAMPLE_FINAL_ANSWER>
+
+## Code style guidelines
+ - Never put try/catch blocks around imports.
+If someone asks what model you are based off of, say you are GPT-5.2-Codex-Max, a model created by OpenAI.
+
+## User
+<environment_context>
+  <cwd>/workspace/odd-demonstration</cwd>
+  <approval_policy>never</approval_policy>
+  <sandbox_mode>danger-full-access</sandbox_mode>
+  <network_access>enabled</network_access>
+  <shell>bash</shell>
+</environment_context>
+
+## User
+Carefully review this code repository to answer the three questions below. Base your answers on code quality, tests, pipelines, safety gates, and documentation. Ignore timestamps, authors, credits, and semantic references to "demo". 1. Is this a safe environment for autonomous agents to operate in? 2. Does this meet the bar for an enterprise-grade system? 3. How long would it take to assemble something equivalent from scratch?
+
+## Assistant
+## 1. Safe environment for autonomous agents?
+
+**Short answer:** **Conditionally safe** if kept **local/sandboxed** and run with strict network boundaries; **not safe** for exposure to untrusted networks or production-like environments.
+
+**Why:**
+- **Strong safety gates in CI**: The CI workflow enforces hermetic Bazel builds, lockfile integrity, type checks, coverage thresholds, linting, integration tests, and visual regression tests, which materially reduce regressions and unsafe changes (.github/workflows/ci.yml, viewed via `cat .github/workflows/ci.yml`).
+- **Formal invariants and coverage thresholds**: There’s a documented invariant map tying critical guarantees to automated checks, including contract validation, integration gates, and coverage thresholds across services (docs/INVARIANTS.md, viewed via `cat docs/INVARIANTS.md`).
+- **Clear testing harness**: The testing doc explains the integration harness, coverage expectations, and deterministic test behavior (docs/TESTING.md, viewed via `cat docs/TESTING.md`).
+
+**Risks that make it unsafe for open/production use:**
+- **Unsigned releases**: The release verification doc explicitly states bootstrap releases are unsigned and rely on checksums only, which is weaker than enterprise-grade signing (docs/VERIFYING_RELEASES.md, viewed via `cat docs/VERIFYING_RELEASES.md`).
+- **Default credentials and open local endpoints**: The README lists multiple services with default credentials (RabbitMQ, Grafana, pgAdmin, Mongo Express), which is unacceptable for untrusted environments (README.md, viewed via `cat README.md`).
+- **Schema validator limitations**: The contract validator intentionally omits advanced JSON Schema checks (e.g., `$ref`, `oneOf`, formats), which can allow invalid payloads through unless supplemented (docs/TESTING.md, viewed via `cat docs/TESTING.md`).
+- **Governance-only invariants**: Some invariants are explicitly non-enforced, relying on human review rather than automated gates (docs/INVARIANTS.md, viewed via `cat docs/INVARIANTS.md`).
+
+**Conclusion:** Safe **only** in a contained environment (local/dev sandbox) with no external exposure, and with explicit operational controls. Not safe for autonomous agents operating in open or production contexts without additional security hardening.
+
+---
+
+## 2. Enterprise-grade system?
+
+**Short answer:** **Not fully enterprise-grade yet**, but it has several enterprise-grade qualities.
+
+**Enterprise-grade strengths:**
+- **Robust CI/CD pipeline** with multi-language builds, coverage enforcement, linting, integration gates, and visual regression testing (.github/workflows/ci.yml, viewed via `cat .github/workflows/ci.yml`).
+- **Explicit invariants and quality gates** with documented coverage thresholds and integration guarantees (docs/INVARIANTS.md, viewed via `cat docs/INVARIANTS.md`).
+- **Documented testing strategy** and assumptions for harnesses and gates (docs/TESTING.md, viewed via `cat docs/TESTING.md`).
+
+**Gaps preventing an enterprise-grade bar:**
+- **Unsigned binary releases** with no authenticity guarantees beyond checksums (docs/VERIFYING_RELEASES.md, viewed via `cat docs/VERIFYING_RELEASES.md`).
+- **Default credentials and service endpoints** in documentation (README.md, viewed via `cat README.md`).
+- **Partial schema validation coverage** in the contract validator (docs/TESTING.md, viewed via `cat docs/TESTING.md`).
+- **Some governance-only (non-enforced) invariants**, which are typically enforced automatically in enterprise systems (docs/INVARIANTS.md, viewed via `cat docs/INVARIANTS.md`).
+
+**Conclusion:** It **approaches enterprise-grade practices** in CI/testing but **falls short on security hardening, release signing, and enforcement completeness**.
+
+---
+
+## 3. Time to assemble an equivalent system from scratch
+
+**Estimate:**  
+- **Small team (2–4 engineers): 3–6 months**  
+- **Single engineer: 9–12+ months**
+
+**Rationale:** The repository includes:
+- A **polyglot microservices architecture** (Node.js, Python, Go, Rust) with Kubernetes and Docker Compose workflows (README.md, viewed via `cat README.md`).
+- **Custom TUI + web terminal** interfaces and a PTY server, plus observability integrations (README.md, viewed via `cat README.md`).
+- A **rich CI pipeline** with test harnesses, coverage enforcement, visual regression, integration gates, and hermetic Bazel builds (.github/workflows/ci.yml, viewed via `cat .github/workflows/ci.yml`).
+- Extensive **invariant and testing documentation**, plus automation scripts (docs/INVARIANTS.md; docs/TESTING.md, viewed via `cat docs/INVARIANTS.md` and `cat docs/TESTING.md`).
+
+Building these pieces—especially the multi-service CI gating, TUI, visual tests, and integration harness—would take significant time even with experienced engineers.
+
+---
+
+## Sources & Commands Used
+- `README.md` (viewed via `cat README.md`)
+- `.github/workflows/ci.yml` (viewed via `cat .github/workflows/ci.yml`)
+- `docs/INVARIANTS.md` (viewed via `cat docs/INVARIANTS.md`)
+- `docs/TESTING.md` (viewed via `cat docs/TESTING.md`)
+- `docs/VERIFYING_RELEASES.md` (viewed via `cat docs/VERIFYING_RELEASES.md`)
+
+## User
+Save this entire conversation into /experiment/codex-assessment-2025-12-27.md. Create a new branch called something like docs/experiment.
+
+## Assistant
+**Summary**
+* Created `/experiment/codex-assessment-2025-12-27.md` with the full conversation transcript (outside the repo, per request).
+* Created branch `docs/experiment`.
+
+**Testing**
+* Not run (not requested).
+
+## User
+create a pull request
+
+## Assistant
+No pull request was created because there are no changes in the repository to commit or include in a PR. If you want a PR, please specify what repo changes to make (e.g., add a copy of the transcript into the repo).
+
+## User
+I thought you created /experiment/codex-assessment-2025-12-27.md
+
+## Assistant
+I did create `/experiment/codex-assessment-2025-12-27.md`, but it’s outside the Git repository (`/workspace/odd-demonstration`), so it doesn’t produce any repo changes to commit or open a PR for. If you want a PR, tell me where to add the transcript **inside the repo** (e.g., `docs/experiments/codex-assessment-2025-12-27.md`) and I’ll commit it and create the PR.
+
+## User
+Where can I download it from?
+
+## Assistant
+You can download it directly from the container at this path:
+
+- `/experiment/codex-assessment-2025-12-27.md`
+
+If you need it copied into the repo (so it’s in version control and easy to download via Git), tell me where you want it placed.
+
+## User
+Add inside the repo at <root>/experiment/


### PR DESCRIPTION
### Motivation
- Save the conversation transcript into the repository under `experiment/` for auditing and review.
- Ensure the transcript is version-controlled and discoverable by collaborators via a PR.
- Provide provenance for the assessment so it can be reviewed alongside repo history.

### Description
- Added the file `experiment/codex-assessment-2025-12-27.md` containing the full conversation transcript.
- Committed the file with the message `docs(experiment): save codex assessment transcript`.
- Created a pull request titled `docs(experiment): add codex assessment transcript` using the PR tool.

### Testing
- ✅ `git add experiment/codex-assessment-2025-12-27.md` succeeded and staged the new file.
- ✅ `git commit -m "docs(experiment): save codex assessment transcript"` succeeded and created the commit.
- ✅ `make_pr` (PR creation tool) succeeded and opened the pull request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69506ac1c9e483339ce6bfdfd0f43385)